### PR TITLE
fix: persist and display only error logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Coverage output
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.3",
         "@typescript-eslint/parser": "^8.59.3",
         "@vitejs/plugin-react": "^5.2.0",
+        "@vitest/coverage-v8": "^4.1.6",
         "eslint": "^9.39.4",
         "happy-dom": "^20.9.0",
         "typescript": "~5.6.2",
@@ -429,6 +430,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emotion/hash": {
@@ -3052,6 +3063,37 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.6.tgz",
+      "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.6",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.6",
+        "vitest": "4.1.6"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
@@ -3319,6 +3361,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -4092,6 +4153,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -4211,6 +4279,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4375,6 +4482,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/min-indent": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.3",
     "@typescript-eslint/parser": "^8.59.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "@vitest/coverage-v8": "^4.1.6",
     "eslint": "^9.39.4",
     "happy-dom": "^20.9.0",
     "typescript": "~5.6.2",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -87,8 +87,8 @@ fn log_path(app: &AppHandle) -> Result<PathBuf, String> {
         .join("ledgera.log.jsonl"))
 }
 
-fn log_event(app: &AppHandle, level: &str, code: &str, message: &str) {
-    log_event_with_details(app, level, code, message, None);
+fn should_log(level: &str) -> bool {
+    level == "error"
 }
 
 fn log_event_with_details(
@@ -98,6 +98,9 @@ fn log_event_with_details(
     message: &str,
     details: Option<String>,
 ) {
+    if !should_log(level) {
+        return;
+    }
     let path = match log_path(app) {
         Ok(p) => p,
         Err(_) => return,
@@ -140,6 +143,14 @@ fn cleanup_old_logs(app: &AppHandle) {
     }
 }
 
+fn filter_log_entries(content: &str) -> Vec<LogEntry> {
+    content
+        .lines()
+        .filter_map(|line| serde_json::from_str::<LogEntry>(line).ok())
+        .filter(|entry| entry.level == "error")
+        .collect()
+}
+
 #[tauri::command]
 fn get_logs(app: AppHandle) -> Result<Vec<LogEntry>, String> {
     let path = log_path(&app)?;
@@ -153,10 +164,7 @@ fn get_logs(app: AppHandle) -> Result<Vec<LogEntry>, String> {
             error.to_string(),
         )
     })?;
-    let mut entries: Vec<LogEntry> = content
-        .lines()
-        .filter_map(|line| serde_json::from_str::<LogEntry>(line).ok())
-        .collect();
+    let mut entries = filter_log_entries(&content);
     entries.reverse();
     Ok(entries)
 }
@@ -372,12 +380,6 @@ async fn fetch_prices(
     symbols: Vec<String>,
 ) -> Result<std::collections::HashMap<String, PriceInfo>, String> {
     let settings = read_settings(&app)?;
-    log_event(
-        &app,
-        "info",
-        "PRICE_FETCH_START",
-        &format!("Fetching prices for {} symbols", symbols.len()),
-    );
 
     if !settings.fetch_prices {
         return Err(to_error_string(
@@ -404,12 +406,6 @@ async fn fetch_prices(
 
     for symbol in &symbols {
         let yahoo_symbol = mapping.get(symbol).unwrap_or(symbol);
-        log_event(
-            &app,
-            "info",
-            "PRICE_FETCH_TRY",
-            &format!("Trying {} → {}", symbol, yahoo_symbol),
-        );
 
         let url = format!(
             "https://query1.finance.yahoo.com/v8/finance/chart/{}",
@@ -427,12 +423,6 @@ async fn fetch_prices(
             .await;
         match response {
             Ok(response) => {
-                log_event(
-                    &app,
-                    "info",
-                    "PRICE_FETCH_RESPONSE",
-                    &format!("Got response for {}", yahoo_symbol),
-                );
                 let body_text = response.text().await.unwrap_or_default();
                 match serde_json::from_str::<serde_json::Value>(&body_text) {
                     Ok(json) => {
@@ -454,31 +444,9 @@ async fn fetch_prices(
                                     formatted,
                                 },
                             );
-                            log_event(
-                                &app,
-                                "info",
-                                "PRICE_FETCHED",
-                                &format!("{} = {} {}", symbol, price, currency),
-                            );
-                        } else {
-                            log_event_with_details(
-                                &app,
-                                "warn",
-                                "PRICE_PARSE_FAILED",
-                                &format!("Could not parse price/currency for {}", symbol),
-                                Some(body_text),
-                            );
                         }
                     }
-                    Err(e) => {
-                        log_event_with_details(
-                            &app,
-                            "warn",
-                            "PRICE_JSON_FAILED",
-                            &format!("Response not valid JSON for {}", symbol),
-                            Some(format!("Parse error: {}\nBody: {}", e, body_text)),
-                        );
-                    }
+                    Err(_) => {}
                 }
             }
             Err(error) => {
@@ -615,8 +583,6 @@ async fn get_balances(app: AppHandle) -> Result<Vec<Balance>, String> {
     let journal_path = require_journal_path(&settings)?;
     let executable = hledger_executable(&settings);
 
-    log_event(&app, "info", "BALANCE_START", "Running hledger balance");
-
     let output = tauri::async_runtime::spawn_blocking(move || {
         Command::new(&executable)
             .arg("-f")
@@ -653,13 +619,6 @@ async fn get_balances(app: AppHandle) -> Result<Vec<Balance>, String> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-    log_event_with_details(
-        &app,
-        "info",
-        "BALANCE_RAW",
-        "hledger balance output",
-        Some(stdout.clone()),
-    );
 
     parse_balance_output(&app, &stdout, &settings, true)
 }
@@ -855,12 +814,6 @@ fn get_app_settings(app: AppHandle) -> Result<AppSettings, String> {
 #[tauri::command]
 fn update_app_settings(app: AppHandle, settings: AppSettings) -> Result<AppSettings, String> {
     let path = settings_path(&app)?;
-    log_event(
-        &app,
-        "info",
-        "SETTINGS_SAVE",
-        &format!("Saving exclude_balances: '{}'", settings.exclude_balances),
-    );
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
             to_error_string_with_details(
@@ -981,15 +934,14 @@ fn list_transactions(app: AppHandle) -> Result<JournalSummary, String> {
 fn create_transaction(app: AppHandle, input: TransactionInput) -> Result<JournalSummary, String> {
     let settings = read_settings(&app)?;
     let result = create_transaction_for_settings(&settings, &input);
-    match &result {
-        Ok(_) => log_event(&app, "info", "TRANSACTION_CREATED", &input.description),
-        Err(e) => log_event_with_details(
+    if let Err(e) = &result {
+        log_event_with_details(
             &app,
             "error",
             "TRANSACTION_CREATE_FAILED",
             "Failed to create transaction",
             Some(e.clone()),
-        ),
+        );
     }
     result
 }
@@ -1003,15 +955,14 @@ fn update_transaction(
 ) -> Result<JournalSummary, String> {
     let settings = read_settings(&app)?;
     let result = update_transaction_for_settings(&settings, &id, &input);
-    match &result {
-        Ok(_) => log_event(&app, "info", "TRANSACTION_UPDATED", &input.description),
-        Err(e) => log_event_with_details(
+    if let Err(e) = &result {
+        log_event_with_details(
             &app,
             "error",
             "TRANSACTION_UPDATE_FAILED",
             "Failed to update transaction",
             Some(e.clone()),
-        ),
+        );
     }
     result
 }
@@ -1021,15 +972,14 @@ fn update_transaction(
 fn delete_transaction(app: AppHandle, id: String) -> Result<JournalSummary, String> {
     let settings = read_settings(&app)?;
     let result = delete_transaction_for_settings(&settings, &id);
-    match &result {
-        Ok(_) => log_event(&app, "info", "TRANSACTION_DELETED", &id),
-        Err(e) => log_event_with_details(
+    if let Err(e) = &result {
+        log_event_with_details(
             &app,
             "error",
             "TRANSACTION_DELETE_FAILED",
             "Failed to delete transaction",
             Some(e.clone()),
-        ),
+        );
     }
     result
 }
@@ -3442,5 +3392,53 @@ mod tests {
         let result = format_posting(&posting);
         assert!(result.contains("@ 45000 USD"));
         assert!(result.contains("; limit order"));
+    }
+
+    #[test]
+    fn should_log_returns_true_only_for_error() {
+        assert!(should_log("error"));
+        assert!(!should_log("info"));
+        assert!(!should_log("warn"));
+        assert!(!should_log("notice"));
+        assert!(!should_log("debug"));
+        assert!(!should_log(""));
+    }
+
+    #[test]
+    fn filter_log_entries_returns_only_error_entries() {
+        let content = r#"
+{"ts":"2025-01-01T00:00:00.000Z","level":"info","code":"TEST","message":"info msg"}
+{"ts":"2025-01-01T00:00:01.000Z","level":"warn","code":"TEST","message":"warn msg"}
+{"ts":"2025-01-01T00:00:02.000Z","level":"error","code":"TEST","message":"error msg"}
+{"ts":"2025-01-01T00:00:03.000Z","level":"error","code":"ERR2","message":"another error"}
+"#;
+
+        let entries = filter_log_entries(content);
+
+        assert_eq!(entries.len(), 2, "should return only error entries");
+        assert_eq!(entries[0].level, "error");
+        assert_eq!(entries[0].message, "error msg");
+        assert_eq!(entries[1].level, "error");
+        assert_eq!(entries[1].message, "another error");
+    }
+
+    #[test]
+    fn filter_log_entries_returns_empty_when_no_errors() {
+        let content = r#"
+{"ts":"2025-01-01T00:00:00.000Z","level":"info","code":"TEST","message":"info msg"}
+{"ts":"2025-01-01T00:00:01.000Z","level":"warn","code":"TEST","message":"warn msg"}
+"#;
+
+        let entries = filter_log_entries(content);
+        assert!(entries.is_empty(), "should be empty when no errors");
+    }
+
+    #[test]
+    fn filter_log_entries_ignores_malformed_lines() {
+        let content =
+            "not json\n{\"level\":\"error\",\"code\":\"OK\",\"message\":\"good\",\"ts\":\"0\"}\n";
+        let entries = filter_log_entries(content);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].message, "good");
     }
 }

--- a/src/routes/LogsRoute.tsx
+++ b/src/routes/LogsRoute.tsx
@@ -4,7 +4,6 @@ import {
   Modal,
   Space,
   Table,
-  Tag,
   Tooltip,
   Typography,
 } from "antd";
@@ -20,17 +19,7 @@ import { useTranslation } from "react-i18next";
 import type { LogEntry } from "./types";
 import styles from "./LogsRoute.module.css";
 
-const levelColors: Record<LogEntry["level"], string> = {
-  info: "blue",
-  warn: "orange",
-  error: "red",
-};
 
-const levelLabels: Record<LogEntry["level"], string> = {
-  info: "INFO",
-  warn: "WARN",
-  error: "ERROR",
-};
 
 export function LogsRoute() {
   const { t } = useTranslation();
@@ -105,14 +94,7 @@ export function LogsRoute() {
               render: (ts: string) =>
                 dayjs(ts).format("YYYY-MM-DD HH:mm:ss"),
             },
-            {
-              title: t("logs.level"),
-              dataIndex: "level",
-              width: 80,
-              render: (level: LogEntry["level"]) => (
-                <Tag color={levelColors[level]}>{levelLabels[level]}</Tag>
-              ),
-            },
+
             {
               title: t("logs.code"),
               dataIndex: "code",


### PR DESCRIPTION
## Summary

Closes #5

Persist and display only error-level log entries. All info/warn calls have been removed from the backend, and the Level/Type column has been dropped from the Logs UI.

## Changes

### Backend (`src-tauri/src/lib.rs`)
- Add `should_log()` helper — returns `true` only for `"error"`
- Add `filter_log_entries()` — testable log-line filtering by level
- `log_event_with_details()` — early return for non-error levels
- `get_logs()` — filter out non-error entries on read
- Remove all 11 info/warn `log_event` calls (PRICE_FETCH_*, BALANCE_*, SETTINGS_SAVE, TRANSACTION_*)
- Remove the unused `log_event()` shorthand
- Keep error-level logging intact (TRANSACTION_*_FAILED, BALANCE_FAILED, PRICE_FETCH_FAILED)

### Frontend (`src/routes/LogsRoute.tsx`)
- Remove the Level/Type column from the logs table
- Remove `levelColors` / `levelLabels` constants
- Remove unused `Tag` import

### Tests
- `should_log_returns_true_only_for_error` — verifies the guard logic
- `filter_log_entries_returns_only_error_entries` — mixed levels filtered correctly
- `filter_log_entries_returns_empty_when_no_errors` — only non-error input
- `filter_log_entries_ignores_malformed_lines` — resilient to bad JSON lines

### Coverage
- All 27 backend tests pass (4 new)
- All 106 frontend tests pass
- Backend line coverage: 57.44%
- Frontend line coverage: 89.85% (LogsRoute not yet covered by frontend tests)