### PR TITLE
feat(autocomplete): add comment suggestions from journal history

### DIFF
--- a/src-tauri/src/journal/autocomplete.rs
+++ b/src-tauri/src/journal/autocomplete.rs
@@ -17,6 +17,7 @@ pub(crate) struct AutocompleteSuggestions {
     descriptions: Vec<String>,
     accounts: Vec<String>,
     commodities: Vec<String>,
+    comments: Vec<String>,
     default_commodity: String,
     default_cash_account: String,
     default_expense_account: String,
@@ -73,6 +74,14 @@ pub(crate) fn get_autocomplete_suggestions(
                 .collect(),
         ),
         commodities,
+        comments: unique_sorted(
+            transactions
+                .iter()
+                .flat_map(|transaction| transaction.postings.iter())
+                .map(|posting| posting.comment.trim().to_string())
+                .filter(|value| !value.is_empty())
+                .collect(),
+        ),
         default_commodity: settings.default_commodity.trim().to_string(),
         default_cash_account: profile.default_cash_account,
         default_expense_account: profile.default_expense_account,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,6 +84,7 @@ function App() {
     descriptionOptions,
     accountOptions,
     commodityOptions,
+    commentOptions,
     defaultCommodity,
     hasConfiguredJournal,
     journalLoadError,
@@ -312,6 +313,7 @@ function App() {
           descriptionOptions={descriptionOptions}
           accountOptions={accountOptions}
           commodityOptions={commodityOptions}
+          commentOptions={commentOptions}
           defaultCommodity={defaultCommodity}
           saveError={transactionError}
           onClose={closeTransactionModalWithCleanup}

--- a/src/components/TransactionModal.tsx
+++ b/src/components/TransactionModal.tsx
@@ -94,10 +94,12 @@ function accountRules(t: (key: string) => string): Rule[] {
 function MovementFields({
   accountOptions,
   commodityOptions,
+  commentOptions,
   defaultCommodity,
 }: {
   accountOptions: { value: string }[];
   commodityOptions: { value: string }[];
+  commentOptions: { value: string }[];
   defaultCommodity: string;
 }) {
   const { t } = useTranslation();
@@ -137,7 +139,7 @@ function MovementFields({
         </Form.Item>
       </div>
       <Form.Item name={["postings", 0, "comment"]} rules={[singleLineRule(t("transactions.single_line_field"))]}>
-        <Input placeholder={t("transactions.comment_placeholder")} />
+        <AutoComplete options={commentOptions} placeholder={t("transactions.comment_placeholder")} filterOption />
       </Form.Item>
     </div>
   );
@@ -146,10 +148,12 @@ function MovementFields({
 function InvestmentFields({
   accountOptions,
   commodityOptions,
+  commentOptions,
   defaultCommodity,
 }: {
   accountOptions: { value: string }[];
   commodityOptions: { value: string }[];
+  commentOptions: { value: string }[];
   defaultCommodity: string;
 }) {
   const { t } = useTranslation();
@@ -211,7 +215,7 @@ function InvestmentFields({
         </Form.Item>
       </div>
       <Form.Item name={["postings", 0, "comment"]} rules={[singleLineRule(t("transactions.single_line_field"))]}>
-        <Input placeholder={t("transactions.comment_placeholder")} />
+        <AutoComplete options={commentOptions} placeholder={t("transactions.comment_placeholder")} filterOption />
       </Form.Item>
     </div>
   );
@@ -221,12 +225,14 @@ function AdvancedPostingRow({
   field,
   accountOptions,
   commodityOptions,
+  commentOptions,
   defaultCommodity,
   onRemove,
 }: {
   field: { key: number; name: number };
   accountOptions: { value: string }[];
   commodityOptions: { value: string }[];
+  commentOptions: { value: string }[];
   defaultCommodity: string;
   onRemove: () => void;
 }) {
@@ -279,7 +285,7 @@ function AdvancedPostingRow({
         name={[field.name, "comment"]}
         rules={[singleLineRule(t("transactions.single_line_field"))]}
       >
-        <Input placeholder={t("transactions.comment_placeholder")} />
+        <AutoComplete options={commentOptions} placeholder={t("transactions.comment_placeholder")} filterOption />
       </Form.Item>
     </div>
   );
@@ -288,11 +294,13 @@ function AdvancedPostingRow({
 function AdvancedPostings({
   accountOptions,
   commodityOptions,
+  commentOptions,
   defaultCommodity,
   validateFormSilently,
 }: {
   accountOptions: { value: string }[];
   commodityOptions: { value: string }[];
+  commentOptions: { value: string }[];
   defaultCommodity: string;
   validateFormSilently: () => void;
 }) {
@@ -325,6 +333,7 @@ function AdvancedPostings({
               field={field}
               accountOptions={accountOptions}
               commodityOptions={commodityOptions}
+              commentOptions={commentOptions}
               defaultCommodity={defaultCommodity}
               onRemove={() => remove(field.name)}
             />
@@ -355,6 +364,7 @@ export function TransactionModal({
   descriptionOptions,
   accountOptions,
   commodityOptions,
+  commentOptions,
   defaultCommodity,
   saveError,
   onClose,
@@ -371,6 +381,7 @@ export function TransactionModal({
   descriptionOptions: { value: string }[];
   accountOptions: { value: string }[];
   commodityOptions: { value: string }[];
+  commentOptions: { value: string }[];
   defaultCommodity: string;
   saveError: string | null;
   onClose: () => void;
@@ -556,6 +567,7 @@ export function TransactionModal({
           <MovementFields
             accountOptions={accountOptions}
             commodityOptions={commodityOptions}
+            commentOptions={commentOptions}
             defaultCommodity={defaultCommodity}
           />
         ) : null}
@@ -563,6 +575,7 @@ export function TransactionModal({
           <InvestmentFields
             accountOptions={accountOptions}
             commodityOptions={commodityOptions}
+            commentOptions={commentOptions}
             defaultCommodity={defaultCommodity}
           />
         ) : null}
@@ -570,6 +583,7 @@ export function TransactionModal({
           <AdvancedPostings
             accountOptions={accountOptions}
             commodityOptions={commodityOptions}
+            commentOptions={commentOptions}
             defaultCommodity={defaultCommodity}
             validateFormSilently={validateFormSilently}
           />

--- a/src/hooks/useJournalData.ts
+++ b/src/hooks/useJournalData.ts
@@ -9,6 +9,7 @@ const emptyAutocompleteSuggestions: AutocompleteSuggestions = {
   descriptions: [],
   accounts: [],
   commodities: [],
+  comments: [],
   defaultCommodity: "",
   defaultCashAccount: "",
   defaultExpenseAccount: "",
@@ -53,6 +54,10 @@ export function useJournalData(settings: AppSettings) {
     () => toAutocompleteOptions(autocompleteSuggestions.commodities),
     [autocompleteSuggestions.commodities],
   );
+  const commentOptions = useMemo(
+    () => toAutocompleteOptions(autocompleteSuggestions.comments),
+    [autocompleteSuggestions.comments],
+  );
 
   return {
     transactionsQuery,
@@ -62,6 +67,7 @@ export function useJournalData(settings: AppSettings) {
     descriptionOptions,
     accountOptions,
     commodityOptions,
+    commentOptions,
     defaultCommodity: autocompleteSuggestions.defaultCommodity || "",
     hasConfiguredJournal,
     journalLoadError: transactionsQuery.isError ? String(transactionsQuery.error) : "",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -140,6 +140,7 @@ export type AutocompleteSuggestions = {
   descriptions: string[];
   accounts: string[];
   commodities: string[];
+  comments: string[];
   defaultCommodity: string;
   defaultCashAccount: string;
   defaultExpenseAccount: string;

--- a/src/utils/account.test.ts
+++ b/src/utils/account.test.ts
@@ -47,6 +47,7 @@ const defaultSuggestions: AutocompleteSuggestions = {
     "revenues:consulting",
   ],
   commodities: ["EUR", "USD"],
+  comments: [],
   defaultCommodity: "EUR",
   defaultCashAccount: "assets:bank:checking",
   defaultExpenseAccount: "expenses:food",


### PR DESCRIPTION
Extracts unique posting comments from all transactions in the journal and exposes them via the existing AutocompleteSuggestions mechanism.

All three transaction modes (movement, investment, advanced) now use AutoComplete instead of plain Input for the comment field.

Closes #30