### PR TITLE
perf: embed autocomplete suggestions in JournalSummary

### DIFF
--- a/src-tauri/src/accounts.rs
+++ b/src-tauri/src/accounts.rs
@@ -18,7 +18,7 @@ pub(crate) async fn get_accounts_overview(
 ) -> Result<AccountsOverview, String> {
     let settings = read_settings(&app)?;
     let journal_path = require_journal_path(&settings)?;
-    let summary = read_journal_summary(&journal_path)?;
+    let summary = read_journal_summary(&journal_path, settings.default_commodity.trim())?;
     let app_for_task = app.clone();
     let settings_for_task = settings.clone();
 

--- a/src-tauri/src/journal/autocomplete.rs
+++ b/src-tauri/src/journal/autocomplete.rs
@@ -1,30 +1,22 @@
-use crate::{
-    journal::{
-        files::{load_journal_files, require_journal_path, JournalFile},
-        parser::load_transactions_from_journal_via_files,
-        types::JournalTransaction,
-    },
-    settings::read_settings,
-};
+use crate::journal::{files::JournalFile, types::JournalTransaction};
 use serde::Serialize;
 use std::collections::HashMap;
-use tauri::AppHandle;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AutocompleteSuggestions {
-    codes: Vec<String>,
-    descriptions: Vec<String>,
-    accounts: Vec<String>,
-    commodities: Vec<String>,
-    comments: Vec<String>,
-    default_commodity: String,
-    default_cash_account: String,
-    default_expense_account: String,
-    default_income_account: String,
-    default_transfer_account: String,
-    default_investment_account: String,
-    default_investment_commodity: String,
+    pub(crate) codes: Vec<String>,
+    pub(crate) descriptions: Vec<String>,
+    pub(crate) accounts: Vec<String>,
+    pub(crate) commodities: Vec<String>,
+    pub(crate) comments: Vec<String>,
+    pub(crate) default_commodity: String,
+    pub(crate) default_cash_account: String,
+    pub(crate) default_expense_account: String,
+    pub(crate) default_income_account: String,
+    pub(crate) default_transfer_account: String,
+    pub(crate) default_investment_account: String,
+    pub(crate) default_investment_commodity: String,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -37,63 +29,8 @@ pub(crate) struct JournalProfile {
     pub(crate) default_investment_commodity: String,
 }
 
-/// Reads distinct values that can be reused while editing transactions.
-#[tauri::command]
-pub(crate) fn get_autocomplete_suggestions(
-    app: AppHandle,
-) -> Result<AutocompleteSuggestions, String> {
-    let settings = read_settings(&app)?;
-    let journal_path = require_journal_path(&settings)?;
-    let files = load_journal_files(&journal_path)?;
-    let transactions = load_transactions_from_journal_via_files(&files)?;
-    let commodities = collect_declared_commodities(&files);
-
-    let profile = build_journal_profile(&transactions, settings.default_commodity.trim());
-
-    Ok(AutocompleteSuggestions {
-        codes: unique_sorted(
-            transactions
-                .iter()
-                .map(|transaction| transaction.code.trim().to_string())
-                .filter(|value| !value.is_empty())
-                .collect(),
-        ),
-        descriptions: unique_sorted(
-            transactions
-                .iter()
-                .map(|transaction| transaction.description.trim().to_string())
-                .filter(|value| !value.is_empty())
-                .collect(),
-        ),
-        accounts: unique_sorted(
-            transactions
-                .iter()
-                .flat_map(|transaction| transaction.postings.iter())
-                .map(|posting| posting.account.trim().to_string())
-                .filter(|value| !value.is_empty())
-                .collect(),
-        ),
-        commodities,
-        comments: unique_sorted(
-            transactions
-                .iter()
-                .flat_map(|transaction| transaction.postings.iter())
-                .map(|posting| posting.comment.trim().to_string())
-                .filter(|value| !value.is_empty())
-                .collect(),
-        ),
-        default_commodity: settings.default_commodity.trim().to_string(),
-        default_cash_account: profile.default_cash_account,
-        default_expense_account: profile.default_expense_account,
-        default_income_account: profile.default_income_account,
-        default_transfer_account: profile.default_transfer_account,
-        default_investment_account: profile.default_investment_account,
-        default_investment_commodity: profile.default_investment_commodity,
-    })
-}
-
 /// Sorts and removes duplicate values.
-fn unique_sorted(mut values: Vec<String>) -> Vec<String> {
+pub(crate) fn unique_sorted(mut values: Vec<String>) -> Vec<String> {
     values.sort_by_key(|value| value.to_lowercase());
     values.dedup_by(|left, right| left.eq_ignore_ascii_case(right));
     values

--- a/src-tauri/src/journal/commands.rs
+++ b/src-tauri/src/journal/commands.rs
@@ -13,12 +13,13 @@ use crate::{
 };
 use tauri::AppHandle;
 
-/// Reads the configured journal and returns parsed transaction blocks.
+/// Reads the configured journal and returns parsed transaction blocks
+/// along with autocomplete suggestions in a single pass.
 #[tauri::command]
 pub(crate) fn list_transactions(app: AppHandle) -> Result<JournalSummary, String> {
     let settings = read_settings(&app)?;
     let journal_path = require_journal_path(&settings)?;
-    read_journal_summary(&journal_path)
+    read_journal_summary(&journal_path, settings.default_commodity.trim())
 }
 
 /// Appends a new transaction using the existing journal style where possible.

--- a/src-tauri/src/journal/summary.rs
+++ b/src-tauri/src/journal/summary.rs
@@ -1,7 +1,10 @@
 use crate::{
     amount_style::parse_amount_style,
     journal::{
-        autocomplete::collect_declared_commodities,
+        autocomplete::{
+            build_journal_profile, collect_declared_commodities, unique_sorted,
+            AutocompleteSuggestions,
+        },
         files::load_journal_files,
         parser::load_transactions_from_journal_via_files,
         types::{DashboardSummary, JournalSummary, JournalTransaction},
@@ -11,7 +14,10 @@ use crate::{
 use chrono::{Datelike, Local, NaiveDate};
 use std::path::Path;
 
-pub(crate) fn read_journal_summary(journal_path: &Path) -> Result<JournalSummary, String> {
+pub(crate) fn read_journal_summary(
+    journal_path: &Path,
+    default_commodity: &str,
+) -> Result<JournalSummary, String> {
     let files = load_journal_files(journal_path)?;
     let file_count = files.len();
     let total_size_bytes: u64 = files.iter().map(|f| f.content.len() as u64).sum();
@@ -22,11 +28,54 @@ pub(crate) fn read_journal_summary(journal_path: &Path) -> Result<JournalSummary
     let transactions = load_transactions_from_journal_via_files(&files)?;
     let commodities = collect_declared_commodities(&files);
     let dashboard = build_dashboard_summary(&transactions);
+    let profile = build_journal_profile(&transactions, default_commodity);
+
+    let suggestions = AutocompleteSuggestions {
+        codes: unique_sorted(
+            transactions
+                .iter()
+                .map(|t| t.code.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect(),
+        ),
+        descriptions: unique_sorted(
+            transactions
+                .iter()
+                .map(|t| t.description.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect(),
+        ),
+        accounts: unique_sorted(
+            transactions
+                .iter()
+                .flat_map(|t| t.postings.iter())
+                .map(|p| p.account.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect(),
+        ),
+        commodities: commodities.clone(),
+        comments: unique_sorted(
+            transactions
+                .iter()
+                .flat_map(|t| t.postings.iter())
+                .map(|p| p.comment.trim().to_string())
+                .filter(|v| !v.is_empty())
+                .collect(),
+        ),
+        default_commodity: default_commodity.to_string(),
+        default_cash_account: profile.default_cash_account,
+        default_expense_account: profile.default_expense_account,
+        default_income_account: profile.default_income_account,
+        default_transfer_account: profile.default_transfer_account,
+        default_investment_account: profile.default_investment_account,
+        default_investment_commodity: profile.default_investment_commodity,
+    };
 
     Ok(JournalSummary {
         path: journal_path.to_string_lossy().to_string(),
         transactions,
         commodities,
+        suggestions,
         file_count,
         total_size_bytes,
         amount_style,

--- a/src-tauri/src/journal/transactions.rs
+++ b/src-tauri/src/journal/transactions.rs
@@ -23,7 +23,7 @@ pub(crate) fn create_transaction_for_settings(
     validate_transaction_input(input)?;
     let journal_path = require_journal_path(settings)?;
     append_transaction_routed(settings, &journal_path, input)?;
-    read_journal_summary(&journal_path)
+    read_journal_summary(&journal_path, settings.default_commodity.trim())
 }
 
 pub(crate) fn update_transaction_for_settings(
@@ -45,7 +45,7 @@ pub(crate) fn update_transaction_for_settings(
             &replacement,
         ))
     })?;
-    read_journal_summary(&journal_path)
+    read_journal_summary(&journal_path, settings.default_commodity.trim())
 }
 
 pub(crate) fn delete_transaction_for_settings(
@@ -64,7 +64,7 @@ pub(crate) fn delete_transaction_for_settings(
             "",
         ))
     })?;
-    read_journal_summary(&journal_path)
+    read_journal_summary(&journal_path, settings.default_commodity.trim())
 }
 
 fn validate_transaction_input(input: &TransactionInput) -> Result<(), String> {

--- a/src-tauri/src/journal/types.rs
+++ b/src-tauri/src/journal/types.rs
@@ -1,4 +1,4 @@
-use crate::amount_style::AmountStyle;
+use crate::{amount_style::AmountStyle, journal::autocomplete::AutocompleteSuggestions};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
@@ -7,6 +7,7 @@ pub(crate) struct JournalSummary {
     pub(crate) path: String,
     pub(crate) transactions: Vec<JournalTransaction>,
     pub(crate) commodities: Vec<String>,
+    pub(crate) suggestions: AutocompleteSuggestions,
     pub(crate) file_count: usize,
     pub(crate) total_size_bytes: u64,
     pub(crate) amount_style: AmountStyle,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -79,7 +79,6 @@ pub fn run() {
             sync::git_pull_journal,
             sync::git_commit_and_push_journal,
             updates::check_for_updates,
-            journal::autocomplete::get_autocomplete_suggestions,
             journal::commands::list_transactions,
             journal::search::search_journal,
             journal::commands::create_transaction,
@@ -285,7 +284,7 @@ mod tests {
             "2026-05-02 Split\n    expenses:office  10 EUR\n    assets:cash\n",
         );
 
-        let summary = read_journal_summary(&main).expect("split journal should load");
+        let summary = read_journal_summary(&main, "").expect("split journal should load");
 
         assert_eq!(summary.transactions.len(), 2);
         assert!(summary
@@ -320,7 +319,7 @@ mod tests {
             "P 2026-05-16 XEON €148,70087\n",
         );
 
-        let summary = read_journal_summary(&main).expect("tree journal should load");
+        let summary = read_journal_summary(&main, "").expect("tree journal should load");
 
         assert_eq!(summary.transactions.len(), 2);
         assert!(summary
@@ -497,7 +496,7 @@ mod tests {
             "2026-05-02 Original\n    expenses:office  10 EUR\n    assets:cash\n",
         );
         let settings = settings_for(&main);
-        let summary = read_journal_summary(&main).expect("summary should load");
+        let summary = read_journal_summary(&main, "").expect("summary should load");
         let transaction_id = summary.transactions[0].id.clone();
 
         update_transaction_for_settings(
@@ -510,7 +509,7 @@ mod tests {
         assert!(updated_content.contains("2026-05-02 * Updated"));
         assert!(!updated_content.contains("Original"));
 
-        let updated_summary = read_journal_summary(&main).expect("updated summary should load");
+        let updated_summary = read_journal_summary(&main, "").expect("updated summary should load");
         delete_transaction_for_settings(&settings, &updated_summary.transactions[0].id)
             .expect("source subjournal transaction should delete");
         let deleted_content = fs::read_to_string(&may).expect("may should be readable");

--- a/src/hooks/useAppSettings.ts
+++ b/src/hooks/useAppSettings.ts
@@ -37,13 +37,12 @@ export function useAppSettings({
       if (prev.journalPath !== next.journalPath) {
         queryClient.resetQueries({ queryKey: ["transactions"] });
         await queryClient.invalidateQueries({ queryKey: ["transactions"] });
-        await queryClient.invalidateQueries({ queryKey: ["autocomplete-suggestions"] });
       }
       if (prev.hledgerPath !== next.hledgerPath) {
         await queryClient.invalidateQueries({ queryKey: ["hledger-status"] });
       }
       if (prev.defaultCommodity !== next.defaultCommodity) {
-        await queryClient.invalidateQueries({ queryKey: ["autocomplete-suggestions"] });
+        await queryClient.invalidateQueries({ queryKey: ["transactions"] });
       }
       if (prev.excludeBalances !== next.excludeBalances) {
         await queryClient.invalidateQueries({ queryKey: ["balances"] });

--- a/src/hooks/useGitSync.ts
+++ b/src/hooks/useGitSync.ts
@@ -37,7 +37,7 @@ export function useGitSync({
   async function invalidateGitAndJournal(status: GitSyncStatus) {
     queryClient.setQueryData(["git-sync-status"], status);
     await queryClient.invalidateQueries({ queryKey: ["transactions"] });
-    await queryClient.invalidateQueries({ queryKey: ["autocomplete-suggestions"] });
+    await queryClient.invalidateQueries({ queryKey: ["transactions"] });
     await queryClient.invalidateQueries({ queryKey: ["balances"] });
     await queryClient.invalidateQueries({ queryKey: ["investments"] });
   }

--- a/src/hooks/useJournalData.ts
+++ b/src/hooks/useJournalData.ts
@@ -30,14 +30,9 @@ export function useJournalData(settings: AppSettings) {
     refetchOnMount: true,
   });
 
-  const autocompleteQuery = useQuery({
-    queryKey: ["autocomplete-suggestions"],
-    queryFn: () => callCommand<AutocompleteSuggestions>("get_autocomplete_suggestions"),
-    enabled: hasConfiguredJournal,
-    retry: false,
-  });
-
-  const autocompleteSuggestions = autocompleteQuery.data ?? emptyAutocompleteSuggestions;
+  // Suggestions are now embedded in JournalSummary — no separate query needed.
+  const autocompleteSuggestions =
+    transactionsQuery.data?.suggestions ?? emptyAutocompleteSuggestions;
   const codeOptions = useMemo(
     () => toAutocompleteOptions(autocompleteSuggestions.codes),
     [autocompleteSuggestions.codes],
@@ -61,7 +56,6 @@ export function useJournalData(settings: AppSettings) {
 
   return {
     transactionsQuery,
-    autocompleteQuery,
     autocompleteSuggestions,
     codeOptions,
     descriptionOptions,

--- a/src/hooks/useTransactionActions.ts
+++ b/src/hooks/useTransactionActions.ts
@@ -55,7 +55,6 @@ export function useTransactionActions({
 
   async function invalidateJournalData() {
     await queryClient.invalidateQueries({ queryKey: ["transactions"] });
-    await queryClient.invalidateQueries({ queryKey: ["autocomplete-suggestions"] });
   }
 
   const createTransactionMutation = useMutation({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -130,6 +130,7 @@ export type JournalSummary = {
   path: string;
   transactions: JournalTransaction[];
   commodities: string[];
+  suggestions: AutocompleteSuggestions;
   fileCount: number;
   totalSizeBytes: number;
   amountStyle: AmountStyle;


### PR DESCRIPTION
list_transactions now returns suggestions alongside transactions in a single journal parse, eliminating the separate get_autocomplete_suggestions command and its duplicated I/O + parsing pass.

Changes:
- Moved suggestion-building logic from autocomplete.rs into summary.rs.
- JournalSummary gains a 'suggestions' field (AutocompleteSuggestions).
- Removed the get_autocomplete_suggestions Tauri command.
- Frontend reads suggestions from transactionsQuery.data.suggestions instead of a separate autocompleteQuery.
- Consolidated React Query invalidation to ['transactions'] only.

Net: -20 lines, -1 Tauri command, -1 journal parse on every load/mutation.

Closes #32