### PR TITLE
feat: budget report - actuals vs periodic rule goals

### DIFF
--- a/examples/budget-test.journal
+++ b/examples/budget-test.journal
@@ -1,0 +1,55 @@
+; Budget test journal for hledger --budget feature
+commodity €
+commodity $
+
+; ── Actual transactions ──────────────────────────────────────────
+
+2026-01-02 * Client retainer
+    assets:bank:checking                         €2,400.00
+    income:consulting                           -€2,400.00
+
+2026-01-03 * Grocery store
+    expenses:food:groceries                        €86.45
+    liabilities:credit-card                       -€86.45
+
+2026-01-05 ! Rent payment
+    expenses:rent                               €1,250.00
+    assets:bank:checking                       -€1,250.00
+
+2026-01-10 * Salary
+    assets:bank:checking                         €3,200.00
+    income:salary                               -€3,200.00
+
+2026-01-15 Team lunch
+    expenses:meals                                €110.00
+    liabilities:credit-card                      -€110.00
+
+2026-02-01 * (FX-001) USD SaaS subscription
+    expenses:software                              $29.00
+    assets:bank:checking
+
+2026-02-03 * Groceries
+    expenses:food:groceries                       €210.00
+    liabilities:credit-card                      -€210.00
+
+2026-02-05 ! Rent
+    expenses:rent                               €1,250.00
+    assets:bank:checking                       -€1,250.00
+
+2026-02-10 * Salary
+    assets:bank:checking                         €3,200.00
+    income:salary                               -€3,200.00
+
+2026-02-14 Team dinner
+    expenses:meals                                €142.30
+    liabilities:credit-card                      -€142.30
+
+; ── Budget goals (periodic transaction rules) ─────────────────────
+
+~ monthly from 2026-01
+    expenses:food:groceries                       €200.00
+    expenses:meals                                €100.00
+    expenses:rent                               €1,300.00
+    expenses:software                              $50.00
+    income:consulting                           -€3,000.00
+    income:salary                               -€3,200.00

--- a/src-tauri/src/budget.rs
+++ b/src-tauri/src/budget.rs
@@ -1,0 +1,448 @@
+use crate::{
+    amount_style::{format_hledger_display_amount, AmountStyle},
+    app_error::to_error_string_with_details,
+    hledger::hledger_executable,
+    journal::files::require_journal_path,
+    logs,
+    settings::read_settings,
+    AMOUNT_STYLE,
+};
+use chrono::Local;
+use serde::Serialize;
+use std::process::Command;
+use tauri::AppHandle;
+
+use crate::reports::{self, run_command_with_timeout, ReportDateRange, REPORT_TIMEOUT};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BudgetPeriodAmount {
+    pub period: String,
+    pub actual: f64,
+    pub budget: f64,
+    pub remaining: f64,
+    pub pct_used: f64,
+    pub commodity: String,
+    pub actual_formatted: String,
+    pub budget_formatted: String,
+    pub remaining_formatted: String,
+    pub tint: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BudgetRow {
+    pub account: String,
+    pub periods: Vec<BudgetPeriodAmount>,
+    pub total_actual: f64,
+    pub total_budget: f64,
+    pub total_remaining: f64,
+    pub total_pct_used: f64,
+    pub commodity: String,
+    pub total_actual_formatted: String,
+    pub total_budget_formatted: String,
+    pub total_remaining_formatted: String,
+    pub tint: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BudgetReport {
+    pub period_columns: Vec<String>,
+    pub rows: Vec<BudgetRow>,
+}
+
+fn amount_quantity(raw: &serde_json::Value) -> f64 {
+    raw["aquantity"]
+        .get("floatingPoint")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0)
+}
+
+fn amount_commodity(raw: &serde_json::Value) -> String {
+    raw["acommodity"].as_str().unwrap_or("").to_string()
+}
+
+fn format_budget_amount(qty: f64, commodity: &str, raw_bal: &serde_json::Value) -> String {
+    if commodity.is_empty() {
+        return format!("{:.2}", qty);
+    }
+    format_hledger_display_amount(qty, commodity, raw_bal)
+}
+
+fn period_label(period: &serde_json::Value) -> String {
+    let dates = period.as_array();
+    let start = dates
+        .and_then(|d| d.first())
+        .and_then(|date| date["contents"].as_str())
+        .unwrap_or_default();
+    if start.len() >= 10 && start.ends_with("-01") {
+        start[..7].to_string()
+    } else if start.len() >= 10 {
+        start[..10].to_string()
+    } else {
+        start.to_string()
+    }
+}
+
+fn extract_period_amounts(
+    period_data: &[serde_json::Value],
+    _commodity_filter: Option<&str>,
+) -> Vec<(f64, String, serde_json::Value)> {
+    let mut result = Vec::new();
+    for amt in period_data {
+        let comm = amount_commodity(amt);
+        let qty = amount_quantity(amt);
+        result.push((qty, comm, amt.clone()));
+    }
+    result
+}
+
+fn aggregate_period(
+    period_label: &str,
+    actual_amounts: &[(f64, String, serde_json::Value)],
+    budget_amounts: &[(f64, String, serde_json::Value)],
+) -> BudgetPeriodAmount {
+    let actual: f64 = actual_amounts.iter().map(|(q, _, _)| q).sum();
+    let budget: f64 = budget_amounts.iter().map(|(q, _, _)| q).sum();
+    let remaining = budget - actual;
+    let pct_used = if budget != 0.0 {
+        ((actual / budget) * 100.0).clamp(-9999.0, 9999.0)
+    } else {
+        f64::NAN
+    };
+
+    let commodity = actual_amounts
+        .first()
+        .or(budget_amounts.first())
+        .map(|(_, c, _)| c.clone())
+        .unwrap_or_default();
+
+    let raw_bal = actual_amounts
+        .first()
+        .or(budget_amounts.first())
+        .map(|(_, _, r)| r.clone())
+        .unwrap_or(serde_json::Value::Null);
+
+    let tint = if pct_used.is_nan() {
+        "neutral".to_string()
+    } else if pct_used > 100.0 {
+        "negative".to_string()
+    } else if pct_used > 80.0 {
+        "neutral".to_string()
+    } else {
+        "positive".to_string()
+    };
+
+    BudgetPeriodAmount {
+        period: period_label.to_string(),
+        actual,
+        budget,
+        remaining,
+        pct_used,
+        commodity: commodity.clone(),
+        actual_formatted: format_budget_amount(actual, &commodity, &raw_bal),
+        budget_formatted: format_budget_amount(budget, &commodity, &raw_bal),
+        remaining_formatted: format_budget_amount(remaining, &commodity, &raw_bal),
+        tint,
+    }
+}
+
+fn parse_budget_json(stdout: &str) -> Result<BudgetReport, String> {
+    let root: serde_json::Value = serde_json::from_str(stdout).map_err(|e| {
+        to_error_string_with_details(
+            "budget_failed",
+            "Unable to parse budget report output.",
+            e.to_string(),
+        )
+    })?;
+
+    let dates = root["prDates"]
+        .as_array()
+        .ok_or_else(|| {
+            to_error_string_with_details(
+                "budget_failed",
+                "Unable to parse budget report.",
+                "Missing prDates in JSON output.",
+            )
+        })?;
+    let period_columns: Vec<String> = dates.iter().map(period_label).collect();
+
+    let empty_rows = Vec::new();
+    let rows_raw = root["prRows"].as_array().unwrap_or(&empty_rows);
+
+    let mut rows: Vec<BudgetRow> = Vec::new();
+
+    for row in rows_raw {
+        let account = row["prrName"].as_str().unwrap_or("");
+        if account.is_empty() || account == "<unbudgeted>" {
+            continue;
+        }
+
+        if AMOUNT_STYLE.get().is_none() {
+            if let Some(periods) = row["prrAmounts"].as_array() {
+                for period in periods {
+                    if let Some(sides) = period.as_array() {
+                        for side in sides {
+                            if let Some(amounts) = side.as_array() {
+                                if let Some(first_amt) = amounts.first() {
+                                    let style = AmountStyle::from_hledger_json(first_amt);
+                                    let _ = AMOUNT_STYLE.set(style);
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // prrAmounts structure: [period_data_0, period_data_1, ...]
+        // Where each period_data = [[actual_amounts], [budget_amounts]]
+        let prr_data = row["prrAmounts"].as_array();
+
+        let mut periods: Vec<BudgetPeriodAmount> = Vec::new();
+
+        for (i, col) in period_columns.iter().enumerate() {
+            let period_data = prr_data.and_then(|d| d.get(i)).and_then(|d| d.as_array());
+
+            let actual_data = period_data
+                .and_then(|d| d.first())
+                .and_then(|d| d.as_array())
+                .map(|a| a.as_slice())
+                .unwrap_or(&[]);
+            let budget_data = period_data
+                .and_then(|d| d.get(1))
+                .and_then(|d| d.as_array())
+                .map(|a| a.as_slice())
+                .unwrap_or(&[]);
+
+            let actual_amounts = extract_period_amounts(actual_data, None);
+            let budget_amounts = extract_period_amounts(budget_data, None);
+
+            periods.push(aggregate_period(col, &actual_amounts, &budget_amounts));
+        }
+
+        // Compute totals from periods
+        let total_actual: f64 = periods.iter().map(|p| p.actual).sum();
+        let total_budget: f64 = periods.iter().map(|p| p.budget).sum();
+        let total_remaining = total_budget - total_actual;
+        let total_pct_used = if total_budget != 0.0 {
+            ((total_actual / total_budget) * 100.0).clamp(-9999.0, 9999.0)
+        } else {
+            f64::NAN
+        };
+
+        let commodity = periods
+            .iter()
+            .find(|p| !p.commodity.is_empty())
+            .map(|p| p.commodity.clone())
+            .unwrap_or_default();
+
+        let total_tint = if total_pct_used.is_nan() {
+            "neutral"
+        } else if total_pct_used > 100.0 {
+            "negative"
+        } else if total_pct_used > 80.0 {
+            "neutral"
+        } else {
+            "positive"
+        };
+
+        let raw_bal = serde_json::Value::Null;
+
+        rows.push(BudgetRow {
+            account: account.to_string(),
+            periods,
+            total_actual,
+            total_budget,
+            total_remaining,
+            total_pct_used,
+            commodity: commodity.clone(),
+            total_actual_formatted: format_budget_amount(total_actual, &commodity, &raw_bal),
+            total_budget_formatted: format_budget_amount(total_budget, &commodity, &raw_bal),
+            total_remaining_formatted: format_budget_amount(total_remaining, &commodity, &raw_bal),
+            tint: total_tint.to_string(),
+        });
+    }
+
+    rows.sort_by(|a, b| a.account.cmp(&b.account));
+
+    Ok(BudgetReport {
+        period_columns,
+        rows,
+    })
+}
+
+#[tauri::command]
+pub(crate) async fn run_budget_report(
+    app: AppHandle,
+    interval: String,
+    scope: String,
+    begin_date: Option<String>,
+    end_date: Option<String>,
+) -> Result<BudgetReport, String> {
+    reports::validate_grouping(&interval)?;
+
+    let settings = read_settings(&app)?;
+    let journal_path = require_journal_path(&settings)?;
+    let executable = hledger_executable(&settings);
+    let date_range = reports::resolve_report_date_range(
+        &scope,
+        begin_date.as_deref(),
+        end_date.as_deref(),
+        Local::now().date_naive(),
+    )?;
+    let args = hledger_budget_args(&journal_path, &interval, &date_range);
+
+    logs::log_event(
+        &app,
+        "info",
+        "budget_command_start",
+        format!(
+            "Starting hledger budget report: executable='{}', args={:?}.",
+            executable, args
+        ),
+    );
+
+    let mut cmd = Command::new(&executable);
+    cmd.args(&args);
+
+    let output = run_command_with_timeout(cmd, REPORT_TIMEOUT).inspect_err(|error| {
+        logs::log_error(
+            &app,
+            "budget_failed",
+            "hledger budget command did not complete.",
+            error,
+        );
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        logs::log_error(&app, "budget_failed", "hledger budget command failed.", &stderr);
+        return Err(to_error_string_with_details(
+            "budget_failed",
+            "hledger budget command failed.",
+            stderr,
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    parse_budget_json(&stdout)
+}
+
+fn hledger_budget_args(
+    journal_path: &std::path::Path,
+    interval: &str,
+    date_range: &ReportDateRange,
+) -> Vec<String> {
+    let mut args = vec![
+        "-f".to_string(),
+        journal_path.display().to_string(),
+        "balance".to_string(),
+        "--budget".to_string(),
+    ];
+
+    if let Some(begin) = &date_range.begin {
+        args.extend(["-b".to_string(), begin.clone()]);
+    }
+    if let Some(end) = &date_range.end {
+        args.extend(["-e".to_string(), end.clone()]);
+    }
+    if !interval.is_empty() {
+        args.push(interval.to_string());
+    }
+
+    args.extend(["-O".to_string(), "json".to_string()]);
+
+    args
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_budget_json_with_periodic_rules() {
+        // prrAmounts structure: [period_0, period_1] where each period = [[actuals], [budgets]]
+        let json = r#"{
+            "prDates": [
+                [{"contents": "2026-01-01", "tag": "Exact"}, {"contents": "2026-02-01", "tag": "Exact"}],
+                [{"contents": "2026-02-01", "tag": "Exact"}, {"contents": "2026-03-01", "tag": "Exact"}]
+            ],
+            "prRows": [
+                {
+                    "prrName": "expenses:food",
+                    "prrAmounts": [
+                        [
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 86.45}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}],
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 200.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}]
+                        ],
+                        [
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 210.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}],
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 200.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}]
+                        ]
+                    ]
+                },
+                {
+                    "prrName": "expenses:rent",
+                    "prrAmounts": [
+                        [
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 1250.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}],
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 1300.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}]
+                        ],
+                        [
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 1250.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}],
+                            [{"acommodity": "€", "aquantity": {"floatingPoint": 1300.0}, "astyle": {"ascommodityside": "L", "ascommodityspaced": false, "asdecimalmark": ".", "asdigitgroups": [",", [3]], "asprecision": 2}}]
+                        ]
+                    ]
+                },
+                {
+                    "prrName": "<unbudgeted>",
+                    "prrAmounts": null
+                }
+            ],
+            "prTotals": {}
+        }"#;
+
+        let result = parse_budget_json(json).expect("budget JSON should parse");
+        assert_eq!(result.period_columns, vec!["2026-01", "2026-02"]);
+        assert_eq!(result.rows.len(), 2, "should skip <unbudgeted> row");
+        let food = result.rows.iter().find(|r| r.account == "expenses:food").expect("food row should exist");
+        assert_eq!(food.account, "expenses:food");
+
+        // Jan: actual €86.45, budget €200.00
+        let jan = &food.periods[0];
+        assert_eq!(jan.actual, 86.45);
+        assert_eq!(jan.budget, 200.0);
+        assert_eq!(jan.remaining, 113.55);
+        assert!((jan.pct_used - 43.225).abs() < 0.01);
+
+        // Feb: actual €210.00, budget €200.00 (over budget)
+        let feb = &food.periods[1];
+        assert_eq!(feb.actual, 210.0);
+        assert_eq!(feb.budget, 200.0);
+        assert_eq!(feb.remaining, -10.0);
+        assert!((feb.pct_used - 105.0).abs() < 0.01);
+
+        // Totals
+        assert_eq!(food.total_actual, 296.45);
+        assert_eq!(food.total_budget, 400.0);
+        assert!((food.total_pct_used - 74.1125).abs() < 0.01);
+
+        // Rent row
+        let rent = result.rows.iter().find(|r| r.account == "expenses:rent").expect("rent row should exist");
+        assert_eq!(rent.account, "expenses:rent");
+        assert_eq!(rent.periods[0].actual, 1250.0);
+        assert_eq!(rent.periods[0].budget, 1300.0);
+    }
+
+    #[test]
+    fn period_label_formats_dates() {
+        let date = serde_json::json!([
+            {"contents": "2026-01-01", "tag": "Exact"},
+            {"contents": "2026-02-01", "tag": "Exact"}
+        ]);
+        assert_eq!(period_label(&date), "2026-01");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod amount_format;
 mod amount_style;
 mod app_error;
 mod balances;
+mod budget;
 mod hledger;
 mod investments;
 mod journal;
@@ -127,6 +128,7 @@ pub fn run() {
             logs::clear_logs,
             investments::get_investments_overview,
             reports::run_report,
+            budget::run_budget_report,
             balances::get_balances,
             accounts::get_accounts_overview,
         ])

--- a/src-tauri/src/reports.rs
+++ b/src-tauri/src/reports.rs
@@ -19,7 +19,7 @@ use std::{
 };
 use tauri::AppHandle;
 
-const REPORT_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const REPORT_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -700,7 +700,7 @@ fn join_pipe_reader(handle: thread::JoinHandle<Vec<u8>>) -> Vec<u8> {
     handle.join().unwrap_or_default()
 }
 
-fn run_command_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output, String> {
+pub(crate) fn run_command_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output, String> {
     let mut child = cmd
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -763,9 +763,9 @@ fn run_command_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Outpu
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ReportDateRange {
-    begin: Option<String>,
-    end: Option<String>,
+pub(crate) struct ReportDateRange {
+    pub(crate) begin: Option<String>,
+    pub(crate) end: Option<String>,
 }
 
 fn report_error(message: &str, details: impl Into<String>) -> String {
@@ -782,7 +782,7 @@ fn validate_report_type(report_type: &str) -> Result<(), String> {
     }
 }
 
-fn validate_grouping(interval: &str) -> Result<(), String> {
+pub(crate) fn validate_grouping(interval: &str) -> Result<(), String> {
     match interval {
         "" | "-M" | "-Q" | "-Y" => Ok(()),
         _ => Err(report_error(
@@ -835,7 +835,7 @@ fn parse_scope_date(field: &str, value: Option<&str>) -> Result<NaiveDate, Strin
     })
 }
 
-fn resolve_report_date_range(
+pub(crate) fn resolve_report_date_range(
     scope: &str,
     begin_date: Option<&str>,
     end_date: Option<&str>,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
   PieChartOutlined,
   ScheduleOutlined,
   SettingOutlined,
+  FundOutlined,
   SyncOutlined,
 } from "@ant-design/icons";
 
@@ -222,7 +223,8 @@ function App() {
         { key: "accounts", label: "common.accounts", icon: <BankOutlined />, disabled: !hasJournal, shortcut: navShortcut(2) },
         { key: "balances", label: "common.balances", icon: <PieChartOutlined />, disabled: !hasJournal, shortcut: navShortcut(3) },
         { key: "reports", label: "common.reports", icon: <BarChartOutlined />, disabled: !hasJournal, shortcut: navShortcut(4) },
-        { key: "recurring", label: "common.recurring", icon: <ScheduleOutlined />, disabled: !hasJournal, shortcut: navShortcut(5) },
+        { key: "budget", label: "common.budget", icon: <FundOutlined />, disabled: !hasJournal, shortcut: navShortcut(5) },
+        { key: "recurring", label: "common.recurring", icon: <ScheduleOutlined />, disabled: !hasJournal, shortcut: navShortcut(6) },
       ];
 
       if (activeSettings.modules.gitSync.enabled) {
@@ -238,14 +240,14 @@ function App() {
           label: "common.sync",
           icon: <SyncOutlined />,
           disabled: !hasJournal,
-          shortcut: navShortcut(6),
+          shortcut: navShortcut(7),
           badge: syncBadge,
           badgeTone: summary.tone === "danger" ? "danger" : "warning",
         });
       }
 
       if (activeSettings.powerUser) {
-        const logsIndex = activeSettings.modules.gitSync.enabled ? 7 : 6;
+        const logsIndex = activeSettings.modules.gitSync.enabled ? 8 : 7;
         items.push({ key: "logs", label: "logs.title", icon: <FileTextOutlined />, shortcut: navShortcut(logsIndex) });
       }
 

--- a/src/components/AppContent.tsx
+++ b/src/components/AppContent.tsx
@@ -5,6 +5,7 @@ import { CourtesyState } from "./CourtesyState";
 import {
   AccountsRoute,
   BalancesRoute,
+  BudgetRoute,
   LogsRoute,
   RecurringRoute,
   ReportsRoute,
@@ -142,6 +143,7 @@ export function AppContent({
         />
       ),
       logs: <LogsRoute />,
+      budget: <BudgetRoute />,
       reports: <ReportsRoute showDetailedTable={activeSettings.modules.developerTools.enabled} />,
       recurring: (
         <RecurringRoute

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,9 +1,20 @@
 {
+  "budget": {
+    "title": "Budget",
+    "select_and_generate": "Select a scope and interval, then click Generate to compare actuals against budget goals.",
+    "empty": "No budget goals found. Create periodic transactions (~ monthly) to define your budget goals.",
+    "generating": "Generating budget report…",
+    "generate": "Generate",
+    "total": "Total",
+    "period_actual": "Actual",
+    "period_budget": "Budget"
+  },
   "common": {
     "transactions": "Transactions",
     "accounts": "Accounts",
     "balances": "Balances",
     "reports": "Reports",
+    "budget": "Budget",
     "recurring": "Recurring",
     "sync": "Sync",
     "logs": "Logs",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -4,6 +4,7 @@
     "accounts": "Conti",
     "balances": "Saldi",
     "reports": "Report",
+    "budget": "Budget",
     "recurring": "Ricorrenti",
     "sync": "Sync",
     "logs": "Log",
@@ -366,5 +367,15 @@
     "save_failed": "Salvataggio regola periodica fallito.",
     "table_period": "Periodo",
     "not_set": "Non impostata"
+  },
+  "budget": {
+    "title": "Budget",
+    "select_and_generate": "Seleziona un ambito e un intervallo, poi clicca Genera per confrontare gli importi effettivi con gli obiettivi di budget.",
+    "empty": "Nessun obiettivo di budget trovato. Crea transazioni periodiche (~ monthly) per definire i tuoi obiettivi di budget.",
+    "generating": "Generazione report budget…",
+    "generate": "Genera",
+    "total": "Totale",
+    "period_actual": "Effettivo",
+    "period_budget": "Budget"
   }
 }

--- a/src/routes/BudgetRoute.tsx
+++ b/src/routes/BudgetRoute.tsx
@@ -1,0 +1,204 @@
+import { BarChartOutlined } from "@ant-design/icons";
+import { Button, Card, DatePicker, Empty, Progress, Select, Space, Spin, Table } from "antd";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useQuery } from "@tanstack/react-query";
+import { callCommand } from "../utils/command";
+import type { BudgetReport, BudgetRow } from "../types";
+import styles from "./ReportsRoute.module.css";
+
+type BudgetScope = "current_month" | "current_year" | "all_time" | "custom";
+type BudgetGrouping = "" | "-M" | "-Q" | "-Y";
+
+const scopeOptions = [
+  { value: "current_month" as const, labelKey: "reports.scope_current_month" },
+  { value: "current_year" as const, labelKey: "reports.scope_current_year" },
+  { value: "all_time" as const, labelKey: "reports.scope_all_time" },
+  { value: "custom" as const, labelKey: "reports.scope_custom" },
+];
+
+const groupingOptions = [
+  { value: "" as const, labelKey: "reports.grouping_none" },
+  { value: "-M" as const, labelKey: "reports.grouping_month" },
+  { value: "-Q" as const, labelKey: "reports.grouping_quarter" },
+  { value: "-Y" as const, labelKey: "reports.grouping_year" },
+];
+
+function pctColor(pctUsed: number): string {
+  if (Number.isNaN(pctUsed)) return "#1677ff";
+  if (pctUsed > 100) return "#ff4d4f";
+  if (pctUsed > 80) return "#faad14";
+  return "#52c41a";
+}
+
+export function BudgetRoute() {
+  const { t } = useTranslation();
+  const [scope, setScope] = useState<BudgetScope>("current_month");
+  const [grouping, setGrouping] = useState<BudgetGrouping>("-M");
+  const [customBeginDate, setCustomBeginDate] = useState("");
+  const [customEndDate, setCustomEndDate] = useState("");
+
+  const budgetQuery = useQuery({
+    queryKey: ["budget", scope, grouping, customBeginDate, customEndDate],
+    queryFn: () => callCommand<BudgetReport>("run_budget_report", {
+      interval: grouping,
+      scope,
+      beginDate: scope === "custom" ? customBeginDate || null : null,
+      endDate: scope === "custom" ? customEndDate || null : null,
+    }),
+    enabled: false,
+    retry: false,
+  });
+
+  const localizedScopes = useMemo(
+    () => scopeOptions.map((opt) => ({ value: opt.value, label: t(opt.labelKey) })),
+    [t],
+  );
+
+  const localizedGroupings = useMemo(
+    () => groupingOptions.map((opt) => ({ value: opt.value, label: t(opt.labelKey) })),
+    [t],
+  );
+
+  const columns = useMemo(() => {
+    const cols: Parameters<typeof Table<BudgetRow>>[0]["columns"] = [
+      {
+        title: t("transactions.account"),
+        dataIndex: "account",
+        render: (account: string) => <span>{account}</span>,
+      },
+    ];
+
+    const periodColumns = budgetQuery.data?.periodColumns ?? [];
+    for (const period of periodColumns) {
+      cols.push({
+        title: period,
+        align: "right" as const,
+        width: 160,
+        render: (_: unknown, row: BudgetRow) => {
+          const entry = row.periods.find((p) => p.period === period);
+          if (!entry) return "-";
+          return (
+            <div style={{ textAlign: "right" }}>
+              <div style={{ fontSize: 13, color: entry.tint === "negative" ? "#ff4d4f" : entry.tint === "positive" ? "#52c41a" : undefined }}>
+                {entry.actualFormatted} / {entry.budgetFormatted}
+              </div>
+              <Progress
+                percent={Number.isNaN(entry.pctUsed) ? 0 : Math.min(Math.abs(entry.pctUsed), 100)}
+                size="small"
+                strokeColor={pctColor(entry.pctUsed)}
+                showInfo={false}
+                style={{ margin: 0 }}
+              />
+            </div>
+          );
+        },
+      });
+    }
+
+    cols.push({
+      title: t("budget.total"),
+      align: "right" as const,
+      width: 160,
+      render: (_: unknown, row: BudgetRow) => (
+        <div style={{ textAlign: "right" }}>
+          <div style={{ fontSize: 13, fontWeight: 500, color: row.tint === "negative" ? "#ff4d4f" : row.tint === "positive" ? "#52c41a" : undefined }}>
+            {row.totalActualFormatted} / {row.totalBudgetFormatted}
+          </div>
+          <Progress
+            percent={Number.isNaN(row.totalPctUsed) ? 0 : Math.min(Math.abs(row.totalPctUsed), 100)}
+            size="small"
+            strokeColor={pctColor(row.totalPctUsed)}
+            showInfo={false}
+            style={{ margin: 0 }}
+          />
+        </div>
+      ),
+    });
+
+    return cols;
+  }, [budgetQuery.data?.periodColumns, t]);
+
+  const isLoading = budgetQuery.isFetching;
+  const canGenerate = scope !== "custom" || Boolean(customBeginDate && customEndDate);
+  const data = budgetQuery.data?.rows ?? [];
+  const hasError = budgetQuery.isError;
+
+  return (
+    <div className={styles.container}>
+      <Card size="small" className={styles.controls}>
+        <Space wrap>
+          <Select
+            aria-label={t("reports.scope")}
+            value={scope}
+            onChange={setScope}
+            options={localizedScopes}
+            style={{ minWidth: 160 }}
+          />
+          {scope === "custom" ? (
+            <>
+              <DatePicker
+                format="YYYY-MM-DD"
+                placeholder={t("reports.begin_date")}
+                onChange={(_, dateString) => setCustomBeginDate(String(dateString))}
+              />
+              <DatePicker
+                format="YYYY-MM-DD"
+                placeholder={t("reports.end_date")}
+                onChange={(_, dateString) => setCustomEndDate(String(dateString))}
+              />
+            </>
+          ) : null}
+          <Select
+            aria-label={t("reports.grouping")}
+            value={grouping}
+            onChange={setGrouping}
+            options={localizedGroupings}
+            style={{ minWidth: 150 }}
+          />
+          <Button
+            type="primary"
+            icon={<BarChartOutlined />}
+            loading={isLoading}
+            disabled={!canGenerate}
+            onClick={() => budgetQuery.refetch()}
+          >
+            {t("reports.generate")}
+          </Button>
+        </Space>
+      </Card>
+
+      <Card className={styles.report_card}>
+        {isLoading ? (
+          <div className={styles.center_state}>
+            <Spin />
+            <span>{t("reports.generating")}</span>
+          </div>
+        ) : hasError ? (
+          <Empty
+            className={styles.center_state}
+            description={t("reports.generation_failed")}
+          />
+        ) : !budgetQuery.data ? (
+          <Empty
+            className={styles.center_state}
+            description={t("budget.select_and_generate")}
+          />
+        ) : data.length === 0 ? (
+          <Empty
+            className={styles.center_state}
+            description={t("budget.empty")}
+          />
+        ) : (
+          <Table<BudgetRow>
+            rowKey="account"
+            dataSource={data}
+            pagination={false}
+            scroll={{ x: "max-content" }}
+            columns={columns}
+          />
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,6 @@
 export { AccountsRoute } from "./AccountsRoute";
 export { BalancesRoute } from "./BalancesRoute";
+export { BudgetRoute } from "./BudgetRoute";
 export { LogsRoute } from "./LogsRoute";
 export { RecurringRoute } from "./RecurringRoute";
 export { ReportsRoute } from "./ReportsRoute";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,7 +3,7 @@ import type { Dayjs } from "dayjs";
 export type ThemePreference = "system" | "dark" | "light";
 export type LanguagePreference = "system" | "en" | "it";
 
-export type AppView = "transactions" | "accounts" | "balances" | "sync" | "settings" | "logs" | "reports" | "recurring";
+export type AppView = "transactions" | "accounts" | "balances" | "sync" | "settings" | "logs" | "reports" | "recurring" | "budget";
 
 export type AppModuleSettings = {
   enabled: boolean;
@@ -381,4 +381,36 @@ export type PendingRecurringDates = {
 export type GenerateResult = {
   generated: number;
   rules: string[];
+};
+
+export type BudgetPeriodAmount = {
+  period: string;
+  actual: number;
+  budget: number;
+  remaining: number;
+  pctUsed: number;
+  commodity: string;
+  actualFormatted: string;
+  budgetFormatted: string;
+  remainingFormatted: string;
+  tint: AmountTint;
+};
+
+export type BudgetRow = {
+  account: string;
+  periods: BudgetPeriodAmount[];
+  totalActual: number;
+  totalBudget: number;
+  totalRemaining: number;
+  totalPctUsed: number;
+  commodity: string;
+  totalActualFormatted: string;
+  totalBudgetFormatted: string;
+  totalRemainingFormatted: string;
+  tint: AmountTint;
+};
+
+export type BudgetReport = {
+  periodColumns: string[];
+  rows: BudgetRow[];
 };


### PR DESCRIPTION
## Issue #40 - Budget Report (Phase 1)

### Backend (`src-tauri/src/budget.rs`, ~350 loc)
- `run_budget_report` Tauri command calling `hledger balance --budget <interval> -O json`
- Parses the budget JSON output (prDates, prRows with period-level actual/budget amounts)
- Computes remaining, pct_used, and tint per period and total
- Custom `hledger_budget_args` builder (balance --budget, no -V/--infer-market-prices)
- 2 unit tests: period_label parsing + full budget JSON parsing with assertions

### Infrastructure changes
- Made `validate_grouping`, `resolve_report_date_range`, `ReportDateRange`, `run_command_with_timeout`, `REPORT_TIMEOUT` pub(crate) in `reports.rs`

### Frontend (`src/routes/BudgetRoute.tsx`, ~170 loc)
- Scope/interval controls (reuses ReportsRoute pattern)
- Budget-vs-actual table with progress bars per period and total
- Color coding: green <80%, yellow 80-100%, red >100%
- Uses Ant Design Progress bars with dynamic stroke color

### Registration
- AppView extended with `'budget'`
- BudgetReport/BudgetRow/BudgetPeriodAmount TypeScript types
- Navigation item with FundOutlined icon at position 5
- EN/IT translations for budget section
- Route registered in AppContent.tsx

### Test journal
- `examples/budget-test.journal` with periodic rules for testing the budget report

### Verification
- 139 frontend tests pass
- 108 Rust tests pass (2 new budget tests + 106 existing)