### PR TITLE
chore: release v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ledgera",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Michele Broggi",
   "license": "MIT",
   "repository": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ledgera"
-version = "0.1.5"
+version = "0.1.6"
 description = "Just another user interface for managing hledger journal transactions"
 authors = ["Michele Broggi"]
 edition = "2021"


### PR DESCRIPTION
Version bump to v0.1.6 for git-crypt feature release.