### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend checks


### PR DESCRIPTION
Potential fix for [https://github.com/thesmokinator/ledgera/security/code-scanning/1](https://github.com/thesmokinator/ledgera/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit minimal token access unless overridden. For this workflow, the best non-breaking default is:

- `contents: read`

This supports checkout and read-only CI operations while preventing unintended write scopes. Place the block at workflow root (e.g., after `concurrency` and before `jobs`) so both `frontend` and `backend` jobs are covered without duplicating config.

No imports, methods, or external definitions are needed—just YAML configuration in the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
