### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend checks


### PR DESCRIPTION
Potential fix for [https://github.com/thesmokinator/ledgera/security/code-scanning/2](https://github.com/thesmokinator/ledgera/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to both `frontend` and `backend` jobs unless overridden.  
The minimal required permission for this workflow is:

- `contents: read`

Best single fix (no functional behavior change):
- Edit `.github/workflows/ci.yml`
- Insert the root-level block after `concurrency` (or before `jobs`) so structure remains clear and applies globally.

No imports, methods, or dependencies are needed (YAML config change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
