### PR TITLE
fix: use cargo set-version to keep Cargo.lock in sync (#65)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ledgera",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ledgera",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@ant-design/charts": "^2.6.7",

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -24,6 +24,7 @@ case "$VERSION" in
     ;;
 esac
 
+# --- JS / npm side ---
 node - "$VERSION" <<'NODE'
 const fs = require("node:fs");
 
@@ -43,28 +44,23 @@ if (packageLock.packages?.[""]) {
   packageLock.packages[""].version = version;
 }
 writeJson("package-lock.json", packageLock);
-
-function replaceOne(path, pattern, replacement, description) {
-  const input = fs.readFileSync(path, "utf8");
-  if (!pattern.test(input)) {
-    throw new Error(`Could not find ${description} in ${path}`);
-  }
-  fs.writeFileSync(path, input.replace(pattern, replacement));
-}
-
-replaceOne(
-  "src-tauri/Cargo.toml",
-  /(\[package\][\s\S]*?\nversion = ")[^"]+(")/,
-  `$1${version}$2`,
-  "package version",
-);
-
-replaceOne(
-  "src-tauri/Cargo.lock",
-  /(\[\[package\]\]\nname = "ledgera"\nversion = ")[^"]+(")/,
-  `$1${version}$2`,
-  "ledgera package version",
-);
 NODE
+
+# --- Rust / Cargo side ---
+if ! command -v cargo &>/dev/null; then
+  echo "cargo is required but not installed" >&2
+  exit 1
+fi
+
+if ! cargo set-version --help &>/dev/null 2>&1; then
+  echo "cargo-edit (cargo-set-version) is required but not installed" >&2
+  echo "Install it with: cargo install cargo-edit" >&2
+  exit 1
+fi
+
+cargo set-version \
+  --manifest-path src-tauri/Cargo.toml \
+  --package ledgera \
+  "$VERSION"
 
 echo "Updated Ledgera version to $VERSION"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1958,7 +1958,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "ledgera"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",


### PR DESCRIPTION
Closes #65

## What

- Replaces regex-based version replacement for `Cargo.toml` and `Cargo.lock` with `cargo set-version` (from `cargo-edit`), as suggested by @alerque.
- Fixes the current out-of-sync state: `Cargo.lock` and `package-lock.json` now correctly report `0.1.6`.

## Why

The v0.1.6 release manually bumped `Cargo.toml` and `package.json` but forgot to update `Cargo.lock` and `package-lock.json`. Using `cargo set-version` prevents this from happening again by delegating the Cargo side to the proper tooling.

## Notes

- `cargo-edit` must be installed (`cargo install cargo-edit`) for `npm run set-version` to work. The script now checks this and prints a clear error if missing.